### PR TITLE
Added `denyEssentialsHomeTeleport` to config

### DIFF
--- a/src/main/java/com/massivecraft/factions/config/file/MainConfig.java
+++ b/src/main/java/com/massivecraft/factions/config/file/MainConfig.java
@@ -1922,6 +1922,12 @@ public class MainConfig {
                     "if they have homes set in that Faction's territory?")
             private boolean deleteEssentialsHomes = true;
 
+            @Comment("Should we deny a player from teleporting to their essentials home if its located in another Faction's territory?\n" +
+                     "if you have 'deleteEssentialsHomes' to true and you have a roster system on your server, it will delete all homes\n " +
+                     "everytime a player rotates out, but when you have 'denyEssentialsHomeTeleport' to true it will not delete their homes\n" +
+                     "when they get rotated out, rather it will just deny teleporting until they rejoin the faction.")
+            private boolean denyEssentialsHomeTeleport = false;
+
             @Comment("Default Relation allows you to change the default relation for Factions.\n" +
                     "Example usage would be so people can't leave then make a new Faction while Raiding\n" +
                     "  in order to be able to execute commands if the default relation is neutral.")
@@ -1957,6 +1963,11 @@ public class MainConfig {
 
             public boolean isDeleteEssentialsHomes() {
                 return deleteEssentialsHomes;
+            }
+
+            public boolean isDenyEssentialsHomeTeleport()
+            {
+                return denyEssentialsHomeTeleport;
             }
 
             public String getDefaultRelation() {

--- a/src/main/java/com/massivecraft/factions/integration/Essentials.java
+++ b/src/main/java/com/massivecraft/factions/integration/Essentials.java
@@ -24,8 +24,13 @@ public class Essentials {
         essentials = (IEssentials) ess;
         FactionsPlugin plugin = FactionsPlugin.getInstance();
         plugin.getLogger().info("Found and connected to Essentials");
-        if (plugin.conf().factions().other().isDeleteEssentialsHomes()) {
-            plugin.getLogger().info("Based on main.conf will delete Essentials player homes in their old faction when they leave");
+        boolean registerEvent = plugin.conf().factions().other().isDeleteEssentialsHomes() || plugin.conf().factions().other().isDenyEssentialsHomeTeleport();
+        if (registerEvent) {
+            if(plugin.conf().factions().other().isDeleteEssentialsHomes())
+                plugin.getLogger().info("Based on main.conf will delete Essentials player homes in their old faction when they leave");
+
+            if(plugin.conf().factions().other().isDenyEssentialsHomeTeleport())
+                plugin.getLogger().info("Based on main.conf will deny Essentials player homes from teleporting when they leave");
             plugin.getServer().getPluginManager().registerEvents(new EssentialsListener(essentials), plugin);
         }
         if (plugin.conf().factions().homes().isTeleportCommandEssentialsIntegration()) {

--- a/src/main/java/com/massivecraft/factions/listeners/EssentialsListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/EssentialsListener.java
@@ -2,13 +2,14 @@ package com.massivecraft.factions.listeners;
 
 import com.earth2me.essentials.IEssentials;
 import com.earth2me.essentials.User;
-import com.massivecraft.factions.Board;
-import com.massivecraft.factions.FLocation;
-import com.massivecraft.factions.Faction;
-import com.massivecraft.factions.FactionsPlugin;
+import com.massivecraft.factions.*;
 import com.massivecraft.factions.event.FPlayerLeaveEvent;
+import com.massivecraft.factions.util.TL;
+import net.ess3.api.IUser;
 import net.ess3.api.InvalidWorldException;
+import net.ess3.api.events.UserTeleportHomeEvent;
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -58,6 +59,28 @@ public class EssentialsListener implements Listener {
                 FactionsPlugin.getInstance().log(Level.INFO, "FactionLeaveEvent: Removing home %s, player %s, in territory of %s",
                         homeName, event.getfPlayer().getName(), faction.getTag());
             }
+        }
+    }
+
+    @EventHandler
+    public void onTeleportToHomeEvent(UserTeleportHomeEvent e)
+    {
+        if(e.getHomeType() != UserTeleportHomeEvent.HomeType.HOME)
+            return;
+        IUser user = e.getUser();
+        Player p = user.getBase();
+        FPlayer pl = FPlayers.getInstance().getByPlayer(p);
+        if(p.hasPermission("essentials.home.others") || pl.isAdminBypassing())
+            return;
+        Location loc = e.getHomeLocation();
+        Faction factionAt = Board.getInstance().getFactionAt(new FLocation(loc));
+        if(!factionAt.isNormal())
+            return;
+        if(!pl.hasFaction()
+           || (pl.hasFaction() && !pl.getFactionId().equals(factionAt.getId())))
+        {
+            e.setCancelled(true);
+            pl.msg(TL.COMMAND_ESSENTIALS_HOME_DENY, factionAt.getTag());
         }
     }
 }

--- a/src/main/java/com/massivecraft/factions/listeners/EssentialsListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/EssentialsListener.java
@@ -27,6 +27,8 @@ public class EssentialsListener implements Listener {
 
     @EventHandler
     public void onLeave(FPlayerLeaveEvent event) throws Exception {
+        if(!FactionsPlugin.getInstance().conf().factions().other().isDeleteEssentialsHomes())
+            return;
         // Get the USER from their UUID.
         Faction faction = event.getFaction();
         User user = ess.getUser(UUID.fromString(event.getfPlayer().getId()));
@@ -65,7 +67,7 @@ public class EssentialsListener implements Listener {
     @EventHandler
     public void onTeleportToHomeEvent(UserTeleportHomeEvent e)
     {
-        if(e.getHomeType() != UserTeleportHomeEvent.HomeType.HOME)
+        if(e.getHomeType() != UserTeleportHomeEvent.HomeType.HOME || !FactionsPlugin.getInstance().conf().factions().other().isDenyEssentialsHomeTeleport())
             return;
         IUser user = e.getUser();
         Player p = user.getBase();

--- a/src/main/java/com/massivecraft/factions/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/util/TL.java
@@ -296,6 +296,7 @@ public enum TL {
     COMMAND_HOME_TOTELEPORT("to teleport to your faction home"),
     COMMAND_HOME_FORTELEPORT("for teleporting to your faction home"),
     COMMAND_HOME_DESCRIPTION("Teleport to the faction home"),
+    COMMAND_ESSENTIALS_HOME_DENY("&7You &ccan't &7teleport to this home because it's claimed by &c%s&8!"),
 
     COMMAND_INVITE_TOINVITE("to invite someone"),
     COMMAND_INVITE_FORINVITE("for inviting someone"),


### PR DESCRIPTION
If a server has rosters for factions, enabling this option is better than deleting every essentials home every time they rotate out of the faction.

This denies the player from teleporting to the location but then allows it once they rotate into the faction.